### PR TITLE
tcp_conn_validator: Introduce the reachable param

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ The time to sleep in seconds between ‘tries’. Default: 1
 ####`timeout`
 
 Number of seconds to wait before timing out. Default: 60
+
+####`reachable`
+
+Should the server be responding or not

--- a/lib/puppet/provider/tcp_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/tcp_conn_validator/tcp_port.rb
@@ -13,18 +13,32 @@ Puppet::Type.type(:tcp_conn_validator).provide(:tcp_port) do
     timeout = resource[:timeout]
     try_sleep = resource[:try_sleep]
 
-    success = validator.attempt_connection
+    if resource[:reachable]
+      success = validator.attempt_connection
+      debug_msg_success = 'Connected to the host in'
+      debug_msg_not_success = 'Failed to connect to host'
+      notice_msg = 'Failed to connect to the host'
+    else
+      success = !validator.attempt_connection
+      debug_msg_success = 'Host is down after'
+      debug_msg_not_success = 'Host is still up'
+      notice_msg = 'Host is still up'
+    end
 
     while success == false && ((Time.now - start_time) < timeout)
-      Puppet.debug("Failed to connect to the host; sleeping #{try_sleep} seconds before retry")
+      Puppet.debug("#{debug_msg_not_success}; sleeping #{try_sleep} seconds before retry")
       sleep try_sleep
-      success = validator.attempt_connection
+      if resource[:reachable]
+        success = validator.attempt_connection
+      else
+        success = !validator.attempt_connection
+      end
     end
 
     if success
-      Puppet.debug("Connected to the host in #{Time.now - start_time} seconds.")
+      Puppet.debug("#{debug_msg_success} #{Time.now - start_time} seconds.")
     else
-      Puppet.notice("Failed to connect to the host within timeout window of #{timeout} seconds; giving up.")
+      Puppet.notice("#{notice_msg} within timeout window of #{timeout} seconds; giving up.")
     end
 
     success

--- a/lib/puppet/type/tcp_conn_validator.rb
+++ b/lib/puppet/type/tcp_conn_validator.rb
@@ -5,10 +5,7 @@ Puppet::Type.newtype(:tcp_conn_validator) do
           prevent configuration changes from being applied if the host cannot be
           reached, but it could potentially be used for other purposes such as monitoring."
 
-  ensurable do
-    defaultvalues
-    defaultto :present
-  end
+  ensurable
 
   newparam(:name, :namevar => true) do
     desc 'An arbitrary name used as the identity of the resource.'
@@ -19,6 +16,11 @@ Puppet::Type.newtype(:tcp_conn_validator) do
     munge do |value|
       Array(value).first
     end
+  end
+
+  newparam(:reachable) do
+    desc 'Should the server be responding or not'
+    defaultto true
   end
 
   newparam(:port) do


### PR DESCRIPTION
This commit introduces the reachable param. It is by default set to
true, so any tcp_conn_validator will make sure the specified server is
listening on the specified port. When set to false, the check ensure
that the server is not listening to the specified ip:port pair.

It can allow one to take an action once a service has been really shut
down.