### PR TITLE
Add parameter for expected HTTP code

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ The time to sleep in seconds between ‘tries’. Default: 1
 
 Number of seconds to wait before timing out. Default: 60
 
+####`expected_code`
+
+Expected HTTP result code to consider success. Default: 200
+

--- a/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
+++ b/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:http_conn_validator).provide(:http_conn_validator) do
     # If `#create` is called, that means that `#exists?` returned false, which
     # means that the connection could not be established... so we need to
     # cause a failure here.
-    raise Puppet::Error, "Unable to connect to the HTTP server! (#{@validator.http_server}:#{@validator.http_port})"
+    raise Puppet::Error, "Unable to connect to the HTTP server! (#{@validator.http_server}:#{@validator.http_port} with HTTP code #{@validator.expected_code})"
   end
 
   # Returns the existing validator, if one exists otherwise creates a new object
@@ -58,7 +58,13 @@ Puppet::Type.type(:http_conn_validator).provide(:http_conn_validator) do
   #
   # @api private
   def validator
-    @validator ||= PuppetX::PuppetCommunity::HttpValidator.new(resource[:name], resource[:host], resource[:port], resource[:use_ssl], resource[:test_url])
+    @validator ||= PuppetX::PuppetCommunity::HttpValidator.new(
+      resource[:name],
+      resource[:host],
+      resource[:port],
+      resource[:use_ssl],
+      resource[:test_url],
+      resource[:expected_code])
   end
 
 end

--- a/lib/puppet/type/http_conn_validator.rb
+++ b/lib/puppet/type/http_conn_validator.rb
@@ -64,4 +64,18 @@ Puppet::Type.newtype(:http_conn_validator) do
     end
   end
 
+  newparam(:expected_code) do
+    desc 'The HTTP status code that should be expected; defaults to 200.'
+    defaultto 200
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
 end


### PR DESCRIPTION
Allow user to specify the expected HTTP result code.  Defaults to 200.