### PR TITLE
Added verify_peer property to provider.

### DIFF
--- a/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
+++ b/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
@@ -64,7 +64,8 @@ Puppet::Type.type(:http_conn_validator).provide(:http_conn_validator) do
       resource[:port],
       resource[:use_ssl],
       resource[:test_url],
-      resource[:expected_code]
-)
+      resource[:expected_code],
+      resource[:verify_peer]
+    )
   end
 end

--- a/lib/puppet/type/http_conn_validator.rb
+++ b/lib/puppet/type/http_conn_validator.rb
@@ -76,4 +76,10 @@ Puppet::Type.newtype(:http_conn_validator) do
       Integer(value)
     end
   end
+
+  newparam(:verify_peer) do
+    desc 'Whether to verify the peer credentials, if possible. Verification will not take place if the CA certificate is missing'
+    defaultto true
+  end
+
 end

--- a/lib/puppet_x/puppet-community/http_validator.rb
+++ b/lib/puppet_x/puppet-community/http_validator.rb
@@ -9,8 +9,9 @@ module PuppetX
       attr_reader :test_path
       attr_reader :test_headers
       attr_reader :expected_code
+      attr_reader :verify_peer
 
-      def initialize(http_resource_name, http_server, http_port, use_ssl, test_path, expected_code)
+      def initialize(http_resource_name, http_server, http_port, use_ssl, test_path, expected_code, verify_peer)
         if http_resource_name =~ %r{\A#{URI.regexp}\z}
           uri = URI(http_resource_name)
           @http_server = uri.host
@@ -25,6 +26,7 @@ module PuppetX
         end
         @test_headers = { 'Accept' => 'application/json' }
         @expected_code = expected_code
+        @verify_peer = verify_peer
       end
 
       # Utility method; attempts to make an http/https connection to a server.
@@ -33,7 +35,7 @@ module PuppetX
       #
       # @return true if the connection is successful, false otherwise.
       def attempt_connection
-        conn = Puppet::Network::HttpPool.http_instance(http_server, http_port, use_ssl)
+        conn = Puppet::Network::HttpPool.http_instance(http_server, http_port, use_ssl, verify_peer)
 
         response = conn.get(test_path, test_headers)
         unless response.code.to_i == expected_code


### PR DESCRIPTION
While using this provider I ran across an issue that required me to be able to set the verify peer option for Puppet::Network::HttpPool.http_instance to false.  By adding it as a parameter with a default of true, normal behavior if the option is left off, I added the functionality.

