### PR TITLE
README Formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ mongodb_cluster_nodes = ['192.168.0.2:27017', 'node02.foo.bar.com:27017']
 tcp_conn_validator { $mongodb_cluster_nodes : }
 ```
 
-####`host`
+#### `host`
 
 IP address or server DNS name on which the service is supposed to be bound to. Required if the namevar is not a connection string.
 
-####`port`
+#### `port`
 
 Port on which the service is supposed to listen. Required if the namevar is not a connection string.
 
-####`try_sleep`
+#### `try_sleep`
 
 The time to sleep in seconds between ‘tries’. Default: 1
 
-####`timeout`
+#### `timeout`
 
 Number of seconds to wait before timing out. Default: 60
 
@@ -61,35 +61,35 @@ appli_cluster_nodes = ['https://server1.com/test-url', 'https://server2.com/test
 http_conn_validator { $appli_cluster_nodes : }
 ```
 
-####`host`
+#### `host`
 
 IP address or server DNS name on which the service is supposed to be bound to. Required if the namevar is not a connection string.
 
-####`port`
+#### `port`
 
 Port on which the service is supposed to listen. Required if the namevar is not a connection string.
 
-####`use_ssl`
+#### `use_ssl`
 
 Whether the connection will be attempted using https. Default: false
 
-####`test_url`
+#### `test_url`
 
 URL to use for testing if the HTTP server is up. Default: /
 
-####`try_sleep`
+#### `try_sleep`
 
 The time to sleep in seconds between ‘tries’. Default: 1
 
-####`timeout`
+#### `timeout`
 
 Number of seconds to wait before timing out. Default: 60
 
-####`expected_code`
+#### `expected_code`
 
 Expected HTTP result code to consider success. Default: 200
 
-####`verify_peer`
+#### `verify_peer`
 
 Whether to verify the peer credentials, if possible. Verification will not take place if the CA certificate is missing
 


### PR DESCRIPTION
The literal text headers are not displaying correctly. Adding a space allows the
markdown parser to correcty make them a header with a literal string.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fix the `README` file. It is currently not displaying correctly.

#### This Pull Request (PR) fixes the following issues
n/a
