### PR TITLE
replace configtimeout with http_connect_timeout (#54)

### DIFF
--- a/lib/puppet_x/puppet-community/tcp_validator.rb
+++ b/lib/puppet_x/puppet-community/tcp_validator.rb
@@ -28,7 +28,7 @@ module PuppetX
       #
       # @return true if the connection is successful, false otherwise.
       def attempt_connection
-        Timeout.timeout(Puppet[:configtimeout]) do
+        Timeout.timeout(Puppet[:http_connect_timeout]) do
           begin
             TCPSocket.new(@tcp_server, @tcp_port).close
             true


### PR DESCRIPTION
configtimeout is deprecated in favour of  http_connect_timeout and
http_read_timeout.  this PR updates configtimeout with
http_connect_timeout which seems reasonable however im not familiar with
this module so let me know if read_timeout makes more sense

Fixes #54
